### PR TITLE
Add an isNil builtin

### DIFF
--- a/doc/content/guides/language/values.md
+++ b/doc/content/guides/language/values.md
@@ -35,14 +35,17 @@ passed as arguments to other functions.
 
 <!-- example functions -->
 
-# Null
+# Nil
 
-Oba has a singleton `null` value which indicates the absence of a value. It
+Oba has a singleton `nil` value which indicates the absence of a value. It
 is often used as a return value from built-in functions which don't return
-anything. It is not possible for user-code to reference `null` directly. For
-example, the following is not valid code:
+anything. There is no `nil` keyword, so the following code is invalid:
 
 ```
-let x = null
+let x = nil
 ```
+
+However, the user can detect whether a value is nil using `isNil`
+
+<!-- example isNil -->
 

--- a/src/vm/oba_builtins.h
+++ b/src/vm/oba_builtins.h
@@ -44,10 +44,18 @@ Value readLineNative(ObaVM* vm, int argc, Value* argv) {
 }
 
 Value printNative(ObaVM* vm, int argc, Value* argv) {
-  // Assume argc == 1 and argv != NULL
-  printValue(argv[0]);
+  if (argc > 0) {
+    printValue(argv[0]);
+  }
   printf("\n");
   return NIL_VAL;
+}
+
+Value isNilNative(ObaVM* vm, int argc, Value* argv) {
+  if (argc != 1) {
+    return OBA_BOOL(false);
+  }
+  return OBA_BOOL(argv[0].type == VAL_NIL);
 }
 
 Builtin __builtins__[] = {
@@ -56,6 +64,7 @@ Builtin __builtins__[] = {
     {"__native_read_byte", &readByteNative},
     {"__native_read_line", &readLineNative},
     {"__native_print", &printNative},
+    {"isNil", &isNilNative},
     {NULL, NULL}, // Sentinel to mark the end of the array.
 };
 

--- a/src/vm/oba_debug.c
+++ b/src/vm/oba_debug.c
@@ -103,7 +103,7 @@ int disassembleInstruction(Chunk* chunk, int offset) {
   case OP_LOOP:
     return jumpInstruction("OP_LOOP", -1, chunk, offset);
   case OP_CALL:
-    return constantInstruction("OP_CALL", chunk, offset);
+    return byteInstruction("OP_CALL", chunk, offset);
   case OP_CLOSURE: {
     offset++;
     uint8_t constant = chunk->code[offset++];

--- a/src/vm/oba_vm.c
+++ b/src/vm/oba_vm.c
@@ -93,6 +93,7 @@ static bool call(ObaVM* vm, ObjClosure* closure, int arity) {
 static bool callNative(ObaVM* vm, NativeFn native, int arity) {
   Value result = native(vm, arity, vm->stackTop - arity);
   vm->stackTop -= arity;
+  pop(vm);
   push(vm, result);
   return true;
 }

--- a/test/examples/values.oba
+++ b/test/examples/values.oba
@@ -6,3 +6,13 @@ fn call f = f()
 call(hello)
 // end example
 // expect: hello
+
+// example: guides/language/values isNil
+let nil = system::print("print returns nil")
+system::print(isNil(nil)) // true
+system::print(isNil("")) // false
+// end example
+// expect: print returns nil
+// expect: true
+// expect: false
+


### PR DESCRIPTION
Also fixes an error where native functions are not popped off the
stack after being called.