### PR TITLE
Document and test pattern matching

### DIFF
--- a/assets/oba.vim
+++ b/assets/oba.vim
@@ -13,7 +13,7 @@ if exists("b:current_syntax")
 endif
 
 " Keywords
-syn keyword obaLanguageKeywords debug else false fn if let match true while import
+syn keyword obaLanguageKeywords debug else false fn if let match true while import data
 
 " Matches
 syn match obaOp      '[+-/*=]'

--- a/doc/content/guides/language/data.md
+++ b/doc/content/guides/language/data.md
@@ -1,5 +1,5 @@
 ---
-title: "Data"
+title: "Data Types"
 date: 2020-10-30T10:23:58-04:00
 ---
 
@@ -41,3 +41,19 @@ fields that it contains:
 system::print(Motorcycle("Red")) // Prints: (Cycle::Motorcycle,Red)
 ```
 
+## Pattern Matching
+
+Data types can be used as patterns in `match` expressions:
+
+```
+let color = match motorcycle
+  | Bicycle          = "grey"
+  | Motorcycle color = color
+  ;
+
+system::print(color) // Prints: "Red"
+```
+
+For more information on pattern-matching, see [Pattern Matching].
+
+[Pattern Matching]: {{< relref path="pattern_matching.md" >}}

--- a/doc/content/guides/language/pattern_matching.md
+++ b/doc/content/guides/language/pattern_matching.md
@@ -1,0 +1,67 @@
+---
+title: "Pattern Matching"
+date: 2020-10-30T10:23:58-04:00
+---
+
+Oba supports pattern matching on both literal values and [data types] using
+_match expressions_. Match expressions have the form:
+
+```
+match <value> | <pattern> = <expression> | <pattern> = <expression> ... ;
+```
+
+The rules for pattern matching are:
+
+* `value` can be a literal or a variable.
+* `pattern` can be a literal or an instance of a data type (more on this below).
+
+Pattern order also matters: patterns are considered from top to bottom, and the
+first one that matches the value wins.
+
+## Literal Patterns
+
+Literal patterns are the simplest: They match if the given value is equal to the
+literal:
+
+<!-- example literalPatterns -->
+
+The expression above always evaluates to "one", because the literal pattern `1`
+always matches the value `1`.
+
+## Variable Patterns
+
+Variable patterns are almost as simple as literal patterns: They match if the
+given value has the same value as the variable:
+
+<!-- example variablePatterns -->
+
+The expression above always evaluates to "one", because the variable pattern
+`x` always matches the value stored in the variable `x`, by definition.
+
+Variable patterns are a good way to specify a catch-all pattern if none of the
+other patterns in the expression match a value:
+
+<!-- example catchAllPattern -->
+
+## Constructor Patterns
+
+You can use pattern matching to both detect an instance's [data type] _and_
+grab the values stored in in its fields. For example:
+
+<!-- example constructorPatterns -->
+
+## Mixed Patterns
+
+A match expression can use many different patterns at once. Here's an example
+that uses literal, variable, and constructor patterns all at once:
+
+<!-- example mixedPatterns -->
+
+## Error handling
+
+It's possible that none of the patterns in a match expression match the given
+value. In this case an error is raised at runtime. As a best practice, always
+use a catch-all, variable pattern when possible.
+
+[data types]: {{< relref path="/guides/language/data.md" >}}
+

--- a/mod/system.oba.c
+++ b/mod/system.oba.c
@@ -1,12 +1,13 @@
 // Generated automatically from mod/system.oba. Do not edit.
-const char* systemModSource = "fn print value {\n"
-                              "  __native_print(value)\n"
-                              "}\n"
-                              "\n"
-                              "fn readByte {\n"
-                              "  __native_read_byte()\n"
-                              "}\n"
-                              "\n"
-                              "fn readLine {\n"
-                              "  __native_read_line()\n"
-                              "}\n";
+const char* systemModSource =
+"fn print value {\n"
+"  __native_print(value)\n"
+"}\n"
+"\n"
+"fn readByte {\n"
+"  __native_read_byte()\n"
+"}\n"
+"\n"
+"fn readLine {\n"
+"  __native_read_line()\n"
+"}\n";

--- a/mod/time.oba.c
+++ b/mod/time.oba.c
@@ -1,12 +1,12 @@
 // Generated automatically from mod/time.oba. Do not edit.
 const char* timeModSource =
-    "// Now returns the time in seconds since the program started running.\n"
-    "fn now {\n"
-    "  __native_now()\n"
-    "}\n"
-    "\n"
-    "// Sleep makes the calling thread sleep until seconds have elapsed.\n"
-    "fn sleep seconds {\n"
-    " __native_sleep(seconds)\n"
-    "}\n"
-    "\n";
+"// Now returns the time in seconds since the program started running.\n"
+"fn now {\n"
+"  __native_now()\n"
+"}\n"
+"\n"
+"// Sleep makes the calling thread sleep until seconds have elapsed.\n"
+"fn sleep seconds {\n"
+" __native_sleep(seconds)\n"
+"}\n"
+"\n";

--- a/src/vm/oba_value.h
+++ b/src/vm/oba_value.h
@@ -25,6 +25,7 @@
 #define IS_UPVALUE(value) isObjType(value, OBJ_UPVALUE)
 #define IS_MODULE(value) isObjType(value, OBJ_MODULE)
 #define IS_CTOR(value) isObjType(value, OBJ_CTOR)
+#define IS_INSTANCE(value) isObjType(value, OBJ_INSTANCE)
 #define OBJ_TYPE(value) (AS_OBJ(value)->type)
 
 // Macros for converting from Oba to C.
@@ -39,6 +40,7 @@
 #define AS_UPVALUE(value) ((ObjUpvalue*)AS_OBJ(value))
 #define AS_MODULE(value) ((ObjModule*)AS_OBJ(value))
 #define AS_CTOR(value) ((ObjCtor*)AS_OBJ(value))
+#define AS_INSTANCE(value) ((ObjInstance*)AS_OBJ(value))
 
 // Singletions
 #define NIL_VAL ((Value){VAL_NIL, {0}})

--- a/test/examples/pattern_matching.oba
+++ b/test/examples/pattern_matching.oba
@@ -1,0 +1,57 @@
+import "system"
+
+// example: guides/language/pattern_matching literalPatterns
+match 1
+  | 1 = "one"
+  | 2 = "two"
+  ;
+// end example
+
+
+// example: guides/language/pattern_matching variablePatterns
+let x = 1
+
+match 1
+  | x = "one"
+  | 2 = "two"
+  ;
+// end example
+
+// example: guides/language/pattern_matching catchAllPattern
+let value = 3
+
+match value
+  | 1     = "one"
+  | 2     = "two"
+  | value = "big number" // catch-all
+  ;
+// end example
+
+// example: guides/language/pattern_matching constructorPatterns
+data Shape = Square length | Rectangle width height
+
+let shape = Rectangle(3, 4)
+
+let area = match shape
+   | Square l      = l * l
+   | Rectangle w h = w * h
+   ; 
+// end example
+system::print(area) // expect: 12
+
+{
+// example: guides/language/pattern_matching mixedPatterns
+  let value = Square(4)
+  let size = match value
+    | 1             = 1
+    | 2             = 2
+    | Square l      = l * l
+    | Rectangle w h = w * h
+    | value         = value
+    ;
+
+system::print(size) // Prints: 16
+// end example
+}
+// expect: 16
+

--- a/test/examples/values.oba
+++ b/test/examples/values.oba
@@ -7,6 +7,7 @@ call(hello)
 // end example
 // expect: hello
 
+
 // example: guides/language/values isNil
 let nil = system::print("print returns nil")
 system::print(isNil(nil)) // true

--- a/test/language/match/basic.oba
+++ b/test/language/match/basic.oba
@@ -1,3 +1,6 @@
 let value = match "a" | "a" = "a" | "b" = "b" | "c" = "c";
 debug value // expect: a
 
+data Foo = Bar
+
+let bar = Bar()

--- a/test/language/match/data.oba
+++ b/test/language/match/data.oba
@@ -1,0 +1,15 @@
+data Option = None | Some v
+
+let none = None()
+let some = Some("one")
+
+debug match none
+  | None   = "none"
+  | Some s = s
+  ; // expect: none
+
+debug match some
+  | None   = "none"
+  | Some s = s
+  ; // expect: one
+


### PR DESCRIPTION
Fixes #26 Fixes #10 (implicitly). Code can technically define an ADT like:

```
data List = NIL | CONS item list
```

And use that as a sort of linked-list.  We probably want a more optimal data structure eventually :/ 